### PR TITLE
Fix missing closing brace on permits in twitter

### DIFF
--- a/Sources/mechasqueak/RescueBoard/StarSystem.swift
+++ b/Sources/mechasqueak/RescueBoard/StarSystem.swift
@@ -250,7 +250,7 @@ struct StarSystem: CustomStringConvertible, Codable, Equatable {
         
         if let permit = self.permit {
             if let permitName = permit.name {
-                description += " (REQUIRES \(permitName.uppercased()) PERMIT"
+                description += " (REQUIRES \(permitName.uppercased()) PERMIT)"
             } else {
                 description += " (REQUIRES PERMIT)"
             }


### PR DESCRIPTION
Missing closing brace on permits in twitter alerts. I.e.:
- <%MechaSqueak[BOT]> Successfully sent tweet "PC rats needed for a rescue near Fuelum (REQUIRES PILOTS' FEDERATION DISTRICT PERMIT! Call your jumps, rats! Case #0 (...)
vs 
- <%MechaSqueak[BOT]> Successfully sent tweet "PC rats needed for a rescue near Fuelum (REQUIRES PILOTS' FEDERATION DISTRICT PERMIT!**)** Call your jumps, rats! Case #0 (...) 